### PR TITLE
Removed 2 unnecessary stubbings in KickCommandTest.java

### DIFF
--- a/src/test/java/org/kitteh/irc/client/library/command/SecondKickCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/SecondKickCommandTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mockito;
 /**
  * Tests the KickCommand
  */
-public class KickCommandTest {
+public class SecondKickCommandTest {
     private static final String CHANNEL = "#targetchannel";
     private static final String USER = "targetuser";
     private static final String REASON = "bad breath";
@@ -31,51 +31,22 @@ public class KickCommandTest {
         Mockito.when(this.client.getServerInfo()).thenReturn(serverInfo);
         Mockito.when(serverInfo.isValidChannel(Mockito.any())).thenReturn(true);
         Mockito.when(this.client.getDefaultMessageMap()).thenReturn(new SimpleDefaultMessageMap(null));
+        Mockito.when(this.user.getNick()).thenReturn(USER);
     }
+
     /**
-     * Test with strings and no reason.
+     * Test with elements and a reason.
      */
     @Test
-    public void noReasonStrings() {
-        KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.target(USER);
-        command.execute();
-
-        Mockito.verify(this.client).sendRawLine("KICK " + CHANNEL + ' ' + USER);
-    }
-
-    /**
-     * Test with strings and no reason after removal.
-     */
-    @Test
-    public void noReasonAnymore() {
-        KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.reason(REASON);
-        command.target(USER);
-        command.reason(null);
-        command.execute();
-
-        Mockito.verify(this.client).sendRawLine("KICK " + CHANNEL + ' ' + USER);
-    }
-
-
-    /**
-     * Tests a targetless execution.
-     */
-    @Test(expected = IllegalStateException.class)
-    public void noTarget() {
-        KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.execute();
-    }
-
-    /**
-     * Tests a wrong-Client attempt.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void wrongClientUser() {
-        Mockito.when(this.user.getClient()).thenReturn(Mockito.mock(Client.class));
+    public void reasonElements() {
+        Mockito.when(this.user.getClient()).thenReturn(this.client);
 
         KickCommand command = new KickCommand(this.client, CHANNEL);
         command.target(this.user);
+        command.reason(REASON);
+        command.execute();
+
+        Mockito.verify(this.client).sendRawLine("KICK " + CHANNEL + ' ' + USER + " :" + REASON);
     }
+
 }

--- a/src/test/java/org/kitteh/irc/client/library/command/ThirdKickCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/ThirdKickCommandTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mockito;
 /**
  * Tests the KickCommand
  */
-public class KickCommandTest {
+public class ThirdKickCommandTest {
     private static final String CHANNEL = "#targetchannel";
     private static final String USER = "targetuser";
     private static final String REASON = "bad breath";
@@ -31,51 +31,19 @@ public class KickCommandTest {
         Mockito.when(this.client.getServerInfo()).thenReturn(serverInfo);
         Mockito.when(serverInfo.isValidChannel(Mockito.any())).thenReturn(true);
         Mockito.when(this.client.getDefaultMessageMap()).thenReturn(new SimpleDefaultMessageMap(null));
+        Mockito.when(this.client.toString()).thenReturn("CLIENT OMG");
     }
+
+
     /**
-     * Test with strings and no reason.
+     * Confirms toString fires, has info in it.
      */
     @Test
-    public void noReasonStrings() {
+    public void toStringer() {
         KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.target(USER);
-        command.execute();
 
-        Mockito.verify(this.client).sendRawLine("KICK " + CHANNEL + ' ' + USER);
-    }
-
-    /**
-     * Test with strings and no reason after removal.
-     */
-    @Test
-    public void noReasonAnymore() {
-        KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.reason(REASON);
-        command.target(USER);
-        command.reason(null);
-        command.execute();
-
-        Mockito.verify(this.client).sendRawLine("KICK " + CHANNEL + ' ' + USER);
+        Assert.assertTrue(command.toString().contains(CHANNEL));
     }
 
 
-    /**
-     * Tests a targetless execution.
-     */
-    @Test(expected = IllegalStateException.class)
-    public void noTarget() {
-        KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.execute();
-    }
-
-    /**
-     * Tests a wrong-Client attempt.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void wrongClientUser() {
-        Mockito.when(this.user.getClient()).thenReturn(Mockito.mock(Client.class));
-
-        KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.target(this.user);
-    }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 stubbing which stubbed `toString` method is created in `KickCommandTest.before` but never executed in 5 tests: 
`KickCommandTest.noReasonAnymore`, `KickCommandTest.noReasonStrings`, `KickCommandTest.noTarget`, `KickCommandTest.wrongClientUser`, `KickCommandTest.reasonElements`.

2)  1 stubbing which stubbed `getNick` method is created in `KickCommandTest.before` but never executed in 5 tests: 
`KickCommandTest.noReasonAnymore`, `KickCommandTest.noReasonStrings`, `KickCommandTest.noTarget`, `KickCommandTest.wrongClientUser`, `KickCommandTest.toStringer`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.