### PR TITLE
Removed 1 unnecessary stubbing in UserModeCommandTest.java

### DIFF
--- a/src/test/java/org/kitteh/irc/client/library/command/UserModeCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/UserModeCommandTest.java
@@ -57,8 +57,6 @@ public class UserModeCommandTest {
     @Test(expected = IllegalArgumentException.class)
     public void testWithOneSimpleModeChangeButWrongClient() {
         Client clientMock = Mockito.mock(Client.class);
-        Mockito.when(clientMock.getNick()).thenReturn(USER);
-
         UserModeCommand sut = new UserModeCommand(clientMock);
         UserMode mode = this.getUserMode('A', Mockito.mock(Client.class));
         sut.add(ModeStatus.Action.ADD, mode);


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 stubbing which is created in `UserModeCommandTest.testWithOneSimpleModeChangeButWrongClient` but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.